### PR TITLE
Fixed playability issue on Raspberry pi's omxh264dec. 

### DIFF
--- a/app/src/main/java/com/yschi/castscreen/CastService.java
+++ b/app/src/main/java/com/yschi/castscreen/CastService.java
@@ -330,10 +330,11 @@ public class CastService extends Service {
                 if (encodedData == null) {
                     throw new RuntimeException("couldn't fetch buffer at index " + bufferIndex);
                 }
-
-                if ((mVideoBufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
-                    mVideoBufferInfo.size = 0;
-                }
+                // Fixes playability issues on certain h264 decoders including omxh264dec on raspberry pi
+                // See http://stackoverflow.com/a/26684736/4683709 for explanation
+                //if ((mVideoBufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+                //    mVideoBufferInfo.size = 0;
+                //}
 
                 //Log.d(TAG, "Video buffer offset: " + mVideoBufferInfo.offset + ", size: " + mVideoBufferInfo.size);
                 if (mVideoBufferInfo.size != 0) {


### PR DESCRIPTION
Potentially resolves [this issue](https://github.com/JonesChi/CastScreen/issues/2).
Tested with:
a) Samsung Galaxy S4
b) Samsung Note 5 
as sources, and

a) avdec_h264 on Ivybridge/HD 2500
b) avdec_h264 on Baytrail SoC
c) omxh264dec on Raspberry Pi
d) vaapidecode on Baytrail SoC
as receiving-side decoders.
